### PR TITLE
select correct page of episodes when using yugen

### DIFF
--- a/jerry.sh
+++ b/jerry.sh
@@ -812,7 +812,7 @@ get_episode_info() {
         yugen)
             href=$(curl -s "https://raw.githubusercontent.com/bal-mackup/mal-backup/master/anilist/anime/${media_id}.json" |
                 tr -d '\n' | tr '}' '\n' | $sed -nE 's@.*"YugenAnime".*"url": *"([^"]*)".*@\1@p')
-            tmp_episode_info=$(curl -s "${href}watch/" | $sed -nE "s@.*href=\"/([^\"]*)\" title=\"([^\"]*)\".*@\1\t\2@p" | $sed -n "$((progress + 1))p")
+	    tmp_episode_info=$(curl -s "${href}watch/?page=$(((progress + 1) / 49 + 1))" | $sed -nE "s@.*href=\"/([^\"]*)\" title=\"([^\"]*)\".*@\1\t\2@p" | $sed -nE "s@(.*$((progress + 1)) :)@\1@p" )
             tmp_href=$(printf "%s" "$tmp_episode_info" | cut -f1)
             ep_title=$(printf "%s" "$tmp_episode_info" | cut -f2)
             if [ "$dub" = true ]; then


### PR DESCRIPTION
The yugen provider splits episodes into pages of 48 episodes each, this was previously not handled.