### PR TITLE
fix: nix hm-module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -6,7 +6,7 @@ self: {
 }: let
   inherit (lib) mkEnableOption mkPackageOption mkOption types mkIf literalExpression;
 
-  packages = self.packages.${pkgs.stdenvh.hostPlatform.system};
+  packages = self.packages.${pkgs.stdenv.hostPlatform.system};
 
   cfg = config.programs.jerry;
 in {


### PR DESCRIPTION
It was using stdenv`h` which probably was a typo.
Fixed it, tested it and works.