### PR TITLE
docs: fix mpv installation for windows scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ irm get.scoop.sh | iex
 
 ```ps
 scoop bucket add extras
-scoop install git mpv fzf
+scoop install git extras/mpv fzf
 ```
 3. Install windows terminal (you don't need to have a microsoft account for that)
    https://learn.microsoft.com/en-us/windows/terminal/install


### PR DESCRIPTION
mpv is under extras so it should be extras/mpv

Reference: https://scoop.sh/#/apps?q=mpv&id=b05b47128464d8969416289383fbfc69a47353e3